### PR TITLE
sql/schemas: Quote user column to avoid syntax error

### DIFF
--- a/sql/schemas.sql
+++ b/sql/schemas.sql
@@ -2,7 +2,7 @@
 DROP TABLE IF EXISTS guestbook.posts;
 CREATE TABLE guestbook.posts (
     id STRING PRIMARY KEY,
-    user OBJECT(STRICT) AS (
+    "user" OBJECT(STRICT) AS (
         name STRING,
         location GEO_POINT
     ),


### PR DESCRIPTION
user became a reserved keyword in CrateDB, so it needs to be quoted.