### PR TITLE
Fix invalid JDBC URL

### DIFF
--- a/java/documentation.md
+++ b/java/documentation.md
@@ -19,7 +19,7 @@ The application establishes the connection with Crate using the
 `DriverManager.getConnection()` method.
 
 ```java
-Connection connection = DriverManager.getConnection("jdbc:crate//<host>:5432/");
+Connection connection = DriverManager.getConnection("jdbc:crate://<host>:5432/");
 ```
 
 Please, take a look at the Crate JDBC driver documentation to see the


### PR DESCRIPTION
The JDBC URL in the page is invalid, a colon is missing, if you use it this way a strange error about JDBC driver not found is returned...