### PR TITLE
Update pom.xml to use https

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,7 +25,7 @@
             <id>maven-central</id>
             <name>Maven Central</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Central Maven repository no longer supports unsecure access. https has to be used

## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
