### PR TITLE
frontend: Relax depending on the browser's geolocation API when posting

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -179,7 +179,12 @@ angular.module('app', [])
 
     // create new post
     this.submitForm = function() {
-      if (!$scope.formdata.user.location) return;
+
+      // Not all geolocation APIs return values, some users may have disabled them.
+      // When there is no location detected, fill one in as a fallback.
+      // if (!$scope.formdata.user.location) return;
+      if (!$scope.formdata.user.location) $scope.formdata.user.location = [9.744417, 47.413417];
+
       if ($scope.imagedata) {
         uploadBlob($scope.imagedata).then(function(response) {
           $scope.formdata.image_ref = response.data.digest;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,7 +75,7 @@
                 <button type="submit"
                         class="btn btn-success btn-lg btn-block"
                         ng-click="guestbookCtlr.submitForm()"
-                        ng-disabled="formdata.user.location === null || !formdata.user.name || !formdata.text">Submit your post!</button>
+                        ng-disabled="!formdata.user.name || !formdata.text">Submit your post!</button>
               </div>
             </div>
           </form>


### PR DESCRIPTION
### Observation
While working on GH-87, I found that the frontend application requires the browser's geolocation API to work successfully.

### Problem
Not all geolocation APIs return values, some users may have disabled them. 

### Improvement
When there is no location detected, fill one in as a fallback when submitting a new post. This essentially makes the use of the geolocation API optional.
