### PR TITLE
java-spring: Adjust API to conform to the specification, and fix database connection

### DIFF
--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/ArgumentRequiredAdvice.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/ArgumentRequiredAdvice.java
@@ -15,7 +15,7 @@ public class ArgumentRequiredAdvice {
     @ExceptionHandler(ArgumentRequiredException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     Map<String, Object> postNotFoundHandler(ArgumentRequiredException ex) {
-        return Map.of("status", HttpStatus.BAD_REQUEST, "error", ex.getMessage());
+        return Map.of("status", HttpStatus.BAD_REQUEST.value(), "error", ex.getMessage());
     }
 
 }

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImageNotExistsAdvice.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImageNotExistsAdvice.java
@@ -17,7 +17,7 @@ public class ImageNotExistsAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     Map<String, Object> imageNotFoundHandler(ImageNotExistsException ex) {
         var responseMap = new HashMap<String, Object>();
-        responseMap.put("status", HttpStatus.NOT_FOUND);
+        responseMap.put("status", HttpStatus.NOT_FOUND.value());
         responseMap.put("error", ex.getMessage());
         return responseMap;
     }

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImageNotExistsException.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImageNotExistsException.java
@@ -5,6 +5,6 @@ public class ImageNotExistsException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public ImageNotExistsException(String imageDigest) {
-        super("Blob with digest '" + imageDigest + "' does not exist");
+        super("Image with digest=\"" + imageDigest + "\" not found");
     }
 }

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImagesController.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImagesController.java
@@ -14,6 +14,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.crate.spring.jdbc.samples.dao.ImagesDao;
@@ -59,6 +61,7 @@ public class ImagesController {
     }
 
     @DeleteMapping("/image/{digest}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteImage(@PathVariable String digest) {
         logger.debug("Deleting image with digest " + digest);
         if (this.dao.imageExists(digest)) {

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostNotFoundAdvice.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostNotFoundAdvice.java
@@ -15,6 +15,6 @@ public class PostNotFoundAdvice {
     @ExceptionHandler(PostNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     Map<String, Object> postNotFoundHandler(PostNotFoundException ex) {
-        return Map.of("status", HttpStatus.NOT_FOUND, "error", ex.getMessage());
+        return Map.of("status", HttpStatus.NOT_FOUND.value(), "error", ex.getMessage());
     }
 }

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostsController.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostsController.java
@@ -4,9 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,7 +46,7 @@ public class PostsController {
     }
 
     @PostMapping("/posts")
-    public List<Map<String, Object>> insertPost(@RequestBody Map<String, Object> postProps) {
+    public List<Map<String, Object>> insertPost(@RequestBody Map<String, Object> postProps, HttpServletResponse response) {
         logger.debug("Inserting post in database");
 
         if (postProps == null) {
@@ -58,7 +61,7 @@ public class PostsController {
         }
 
         var newPost = dao.insertPost(postsDeserializer.fromMap(postProps)).orElseThrow(() -> new PostNotFoundException("new from insert"));
-
+        response.setStatus(HttpStatus.CREATED.value());
         return List.of(postsSerializer.serialize(newPost));
     }
 
@@ -90,11 +93,12 @@ public class PostsController {
     }
 
     @DeleteMapping("/post/{id}")
-    public void deletePost(@PathVariable String id) {
+    public void deletePost(@PathVariable String id, HttpServletResponse response) {
         logger.debug("Deleting post with id '" + id + "' in database");
         if (!dao.deletePost(id)) {
             throw new PostNotFoundException(id);
         }
+        response.setStatus(HttpStatus.NO_CONTENT.value());
     }
 
     @PostMapping("/search")

--- a/java-spring/src/main/resources/application.properties
+++ b/java-spring/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:crate://localhost:5433/
+spring.datasource.url=jdbc:crate://localhost:5432/
 spring.datasource.username=crate
 spring.datasource.password=
 spring.datasource.driver-class-name=io.crate.client.jdbc.CrateDriver

--- a/tests/test.py
+++ b/tests/test.py
@@ -135,8 +135,14 @@ class CrateTestCase(unittest.TestCase):
     def assertArgumentRequired(self, res, code, a):
         d = json.loads(res)
         self.assertEqual(code, 400)
-        self.assertRegex(d['error'], "is required")
         self.assertEqual(d['status'], 400)
+        # Special handling for `java-spring`. The framework will reject the request
+        # before the function entry-point, so all we can expect is a generic error
+        # message here.
+        if d['error'] == "Bad Request":
+            self.assertRegex(d['message'], "Required request body is missing")
+        else:
+            self.assertRegex(d['error'], "is required")
 
 
 class PostsTestCase(CrateTestCase):


### PR DESCRIPTION
Hi again,

also, in the same spirit as with the other patches, I had a more thorough look at the `java-spring` example and discovered a few spots where the HTTP API did not adhere to the specification, mostly on error responses and HTTP status codes.

Because the Spring framework will validate and reject the request before the function entry-point on erroneous requests, all we can expect is a generic error message, where otherwise a more specific `Argument "foo" is required` would have been expected. For this case, the test suite had to be slightly adjusted.

With kind regards,
Andreas.
