### PR TITLE
go-gin: Suppress "Error strings should not be capitalized" admonition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+!go-gin/.idea

--- a/go-gin/.idea/.gitignore
+++ b/go-gin/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/go-gin/.idea/go-gin.iml
+++ b/go-gin/.idea/go-gin.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/go-gin/.idea/inspectionProfiles/Project_Default.xml
+++ b/go-gin/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="GoErrorStringFormat" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/go-gin/.idea/modules.xml
+++ b/go-gin/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/go-gin.iml" filepath="$PROJECT_DIR$/.idea/go-gin.iml" />
+    </modules>
+  </component>
+</project>

--- a/go-gin/.idea/vcs.xml
+++ b/go-gin/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
GoLand would otherwise display such a warning within the code editor. With 438f6f680, it doesn't.

![image](https://user-images.githubusercontent.com/453543/213255520-71a9e4e5-0700-46b3-8b30-548fb1edda8a.png)
