### PR TITLE
java-spring: Update Spring Boot libraries

### DIFF
--- a/java-spring/build.gradle
+++ b/java-spring/build.gradle
@@ -14,11 +14,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.4.13")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.7.7")
     }
 }
 
-version = '0.0.1-SNAPSHOT'
+version = '0.1.0-SNAPSHOT'
 
 processResources.destinationDir = compileJava.destinationDir
 compileJava.dependsOn processResources
@@ -39,10 +39,10 @@ repositories {
 dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'io.crate:crate-jdbc:2.6.0'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:2.4.13'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc:2.4.13'
-    implementation 'org.springframework.boot:spring-boot-starter-web:2.4.13'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.4.13'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:2.7.7'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc:2.7.7'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.7'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.7'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java-spring/build.gradle
+++ b/java-spring/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'org.springframework.boot'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.7.7")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:3.0.1")
     }
 }
 
@@ -39,10 +39,10 @@ repositories {
 dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'io.crate:crate-jdbc:2.6.0'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:2.7.7'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc:2.7.7'
-    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.7'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.7'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc:3.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-web:3.0.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java-spring/build.gradle
+++ b/java-spring/build.gradle
@@ -1,3 +1,4 @@
+// https://mvnrepository.com/artifact/org.springframework.boot
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
@@ -13,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.13.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.4.13")
     }
 }
 
@@ -36,12 +37,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.crate:crate-jdbc:2.6.0'
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'org.springframework.boot:spring-boot-starter-web:2.2.13.RELEASE'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:2.2.13.RELEASE'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc:2.2.13.RELEASE'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.2.13.RELEASE'
+    implementation 'io.crate:crate-jdbc:2.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:2.4.13'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc:2.4.13'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.4.13'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.4.13'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImagesController.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImagesController.java
@@ -7,7 +7,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImagesController.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/ImagesController.java
@@ -72,7 +72,7 @@ public class ImagesController {
     }
 
     @PostMapping("/images")
-    public Map<String, String> insertImage(@RequestBody Map<String, Object> imageProps, HttpServletResponse response) {
+    public Map<String, String> insertImage(@RequestBody(required=false) Map<String, Object> imageProps, HttpServletResponse response) {
         logger.debug("Inserting image into database");
         if (imageProps == null) {
             throw new ArgumentRequiredException("Request body is required");

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostsController.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostsController.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostsController.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/PostsController.java
@@ -46,7 +46,7 @@ public class PostsController {
     }
 
     @PostMapping("/posts")
-    public List<Map<String, Object>> insertPost(@RequestBody Map<String, Object> postProps, HttpServletResponse response) {
+    public List<Map<String, Object>> insertPost(@RequestBody(required=false) Map<String, Object> postProps, HttpServletResponse response) {
         logger.debug("Inserting post in database");
 
         if (postProps == null) {
@@ -72,7 +72,7 @@ public class PostsController {
     }
 
     @PutMapping("/post/{id}")
-    public Map<String, Object> updatePost(@PathVariable String id, @RequestBody Map<String, Object> postProps) {
+    public Map<String, Object> updatePost(@PathVariable String id, @RequestBody(required=false) Map<String, Object> postProps) {
         logger.debug("Updating post with id '" + id + "' in database");
 
         if (postProps == null) {

--- a/java-spring/src/main/java/io/crate/spring/jdbc/samples/SpringDataJdbcConfiguration.java
+++ b/java-spring/src/main/java/io/crate/spring/jdbc/samples/SpringDataJdbcConfiguration.java
@@ -1,0 +1,32 @@
+package io.crate.spring.jdbc.samples;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.PostgresDialect;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Configuration
+public class SpringDataJdbcConfiguration extends AbstractJdbcConfiguration {
+    /**
+     * Provide a custom JDBC configuration to set the dialect for the `crate` JDBC driver.
+     * For now, Spring Data JDBC's `PostgresDialect` is used as a reasonable default.
+     * -- https://stackoverflow.com/a/62545740
+     *
+     * @param operations the {@link NamedParameterJdbcOperations} allowing access to a {@link java.sql.Connection}.
+     * @return
+     */
+    @Override
+    public Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
+        return operations.getJdbcOperations().execute((ConnectionCallback<Dialect>)
+                connection -> isCrateDB(connection) ? PostgresDialect.INSTANCE : super.jdbcDialect(operations));
+    }
+
+    private boolean isCrateDB(Connection connection) throws SQLException {
+        return connection.getMetaData().getDatabaseProductName().toLowerCase().contains("crate");
+    }
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -136,13 +136,7 @@ class CrateTestCase(unittest.TestCase):
         d = json.loads(res)
         self.assertEqual(code, 400)
         self.assertEqual(d['status'], 400)
-        # Special handling for `java-spring`. The framework will reject the request
-        # before the function entry-point, so all we can expect is a generic error
-        # message here.
-        if d['error'] == "Bad Request":
-            self.assertRegex(d['message'], "Required request body is missing")
-        else:
-            self.assertRegex(d['error'], "is required")
+        self.assertRegex(d['error'], "is required")
 
 
 class PostsTestCase(CrateTestCase):


### PR DESCRIPTION
#### About
What the title says. The gist from 112fbee6, providing a custom JDBC configuration (per `SpringDataJdbcConfiguration`) **to set the dialect for the `crate` JDBC driver** (needed starting with Spring Boot 2.3), can be used in other contexts as well. Currently, it configures Spring/Hibernate to use Spring Data JDBC's `PostgresDialect` as a reasonable default.

#### Fixes
- GH-121

#### Resolves
- GH-103
- GH-108
- GH-116
- GH-118
