### PR TITLE
Go: Drop support for Go 1.24. Validate with Go 1.26.

### DIFF
--- a/.github/workflows/test-go-gin.yml
+++ b/.github/workflows/test-go-gin.yml
@@ -38,8 +38,8 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         go-version: [
-          '1.24.x',
           '1.25.x',
+          '1.26.x',
         ]
         cratedb-version: [ 'nightly' ]
 

--- a/go-gin/go.mod
+++ b/go-gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/sergesheff/crate-sample-apps/golang
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/georgysavva/scany/v2 v2.1.4


### PR DESCRIPTION
Just maintenance.